### PR TITLE
cometのtypoを修正

### DIFF
--- a/allAssignables.dat
+++ b/allAssignables.dat
@@ -6,7 +6,7 @@
 バスカー (Busker);busker
 カノン (Cannon) <bdg s>;cannon
 コレイター (臨床検査技師, Collator) <bdg n>;collator
-コメット (Commet);commet
+コメット (Comet);comet
 ドクター (Doctor);doctor
 ジャスティス (天秤, Justice) <bdg n>;justice
 マッドメイト (Madmate);madmate


### PR DESCRIPTION
Cometのtypoにより

- ヘッダからCometの説明ページに飛べない問題
- Cometの名前の括弧内がCom**m**etになっている問題

を修正しました